### PR TITLE
Analytics margin overlap

### DIFF
--- a/cms-app/src/pages/analytics-page.jsx
+++ b/cms-app/src/pages/analytics-page.jsx
@@ -26,11 +26,12 @@ function AnalyticsPage() {
   }
 
   // Main render
-  return (
-    <div className="p-4" style={{ marginTop: '80px' }}>
-      <HamburgerMenu />
-      <h1 className="mb-4">Analytics Dashboard</h1>
-      <Stack direction="horizontal" gap={3} className='mb-4'>
+return (
+  <div className="p-3">
+    <HamburgerMenu />
+    <div style={{ marginLeft: '60px' }}>
+      <h1 className="mb-3">Analytics Dashboard</h1>
+      <Stack direction="horizontal" gap={30} className='mb-3'>
         <Button variant={activeView === 'graphs' ? 'primary' : 'outline-primary'} onClick={() => setActiveView('graphs')}>
           View Graphs
         </Button>
@@ -43,7 +44,8 @@ function AnalyticsPage() {
       </Stack>
       {renderTab()}
     </div>
-  );
+  </div>
+);
 }
 
 export default AnalyticsPage;


### PR DESCRIPTION
##The hamburger menu was overlapping with the "Analytics Dashboard" header, making the header text partially unreadable.

##Changes:
- Added proper margin to analytics page content

- Ensured hamburger menu remains in top-left corner

- Fixed header and content positioning to prevent overlap

##Files Changed:
-analytics-page.jsx (layout and margin fixes)